### PR TITLE
Node updates 20230129

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ exports.mainnet = [
   "mainnet.api.tez.ie",
   "mainnet.smartpy.io",
   "rpc.tzbeta.net",
-  "rpc-mainnet.ateza.io",
   "eu01-node.teztools.net",
   "rpc.tzkt.io/mainnet",
 ]

--- a/index.js
+++ b/index.js
@@ -13,3 +13,16 @@ exports.hangzhounet = [
   "rpc-testnet-one.ateza.io",
   "rpc.tzkt.io/hangzhou2net",
 ]
+
+exports.kathmandunet = [
+  "https://kathmandunet.smartpy.io/",
+]
+
+exports.limanet = [
+  "https://limanet.ecadinfra.com",
+]
+
+exports.ghostnet = [
+  "https://ghostnet.ecadinfra.com",
+  "https://ghostnet.tezos.marigold.dev/",
+]

--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ exports.mainnet = [
 exports.hangzhounet = [
   "hangzhounet.api.tez.ie",
   "hangzhounet.smartpy.io",
-  "rpc-testnet-one.ateza.io",
   "rpc.tzkt.io/hangzhou2net",
 ]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@versumstudios/rpc-node",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "full list of rpc nodes",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Probably should deprecate hangzhounet completely in the versum UI in favour of ghostnet which will require new contracts deploying

https://tezos.gitlab.io/introduction/test_networks.html